### PR TITLE
fix lib type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 http-body-util = "0.1.3"
 wstd = "0.6"


### PR DESCRIPTION
We forgot to add a `cdylib` crate type when migrating off of `cargo-component` in https://github.com/bytecodealliance/sample-wasi-http-rust/pull/81. Thanks!